### PR TITLE
fix: docker環境にbs4を導入する修正

### DIFF
--- a/docker_files/Dockerfile
+++ b/docker_files/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /usr/src/app
 
 RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools
-RUN pip install poetry
+RUN pip install poetry bs4


### PR DESCRIPTION
## 発生したこと

Docker環境にてget_valueを実行したところ、以下のエラーが発生しました。

```sh
% docker-compose exec app python script/get_value
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/src/app/script/get_value/__main__.py", line 5, in <module>
    from service.scraping import Scraping
  File "/usr/src/app/service/scraping.py", line 2, in <module>
    from bs4 import BeautifulSoup
ModuleNotFoundError: No module named 'bs4'
```

コンテナを立て直せば (`docker-compose down` -> `docker-compose up` を実行すれば) 再現できると思います。

## 原因

以下の読み込みに失敗していたためでした。

https://github.com/koba-masa/my_scraping_tool/blob/49cdb9d69c339a049c0b3bd2e904f12ca5c625f5/service/scraping.py#L2